### PR TITLE
fix(wifi): add wifi-unredactor fallback for macOS 26 SSID redaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# macOS
+.DS_Store
+**/.DS_Store

--- a/plugins/wifi/click.sh
+++ b/plugins/wifi/click.sh
@@ -6,6 +6,10 @@ command -v 'menubar' 2>/dev/null 1>&2 || alias menubar="$RELPATH/menubar"
 WIFI_PORT=$(networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}')
 WIFI=$(ipconfig getsummary $WIFI_PORT | awk -F': ' '/ SSID : / {print $2}')
 
+if [[ "$WIFI" == *"redacted"* ]] && [[ -x ~/Applications/wifi-unredactor.app/Contents/MacOS/wifi-unredactor ]]; then
+  WIFI=$(~/Applications/wifi-unredactor.app/Contents/MacOS/wifi-unredactor 2>/dev/null | jq -r '.ssid // "<redacted>"' 2>/dev/null)
+fi
+
 ### Depending on click type, show wifi popup or deactivate wifi 
 
 if [[ $BUTTON == "left" ]]; then

--- a/plugins/wifi/script.sh
+++ b/plugins/wifi/script.sh
@@ -10,6 +10,9 @@ ICON_WIFI_OFF=􀙈
 getname() {
   WIFI_PORT=$(networksetup -listallhardwareports | awk '/Hardware Port: Wi-Fi/{getline; print $2}')
   WIFI="$(system_profiler SPAirPortDataType | awk '/Current Network/ {getline;$1=$1; gsub(":",""); print;exit}')" #$(ipconfig getsummary $WIFI_PORT | awk -F': ' '/ SSID : / {print $2}')
+  if [[ "$WIFI" == *"redacted"* ]] && [[ -x ~/Applications/wifi-unredactor.app/Contents/MacOS/wifi-unredactor ]]; then
+    WIFI=$(~/Applications/wifi-unredactor.app/Contents/MacOS/wifi-unredactor 2>/dev/null | jq -r '.ssid // "<redacted>"' 2>/dev/null)
+  fi
   HOTSPOT=$(ipconfig getsummary $WIFI_PORT | grep sname | awk '{print $3}')
   IP_ADDRESS=$(scutil --nwi | grep address | sed 's/.*://' | tr -d ' ' | head -1)
   PUBLIC_IP=$(curl -m 2 https://ipinfo.io 2>/dev/null 1>&2; echo $?)
@@ -41,7 +44,7 @@ getname() {
     ICON_COLOR=$SUBTLE
     LABEL="$WIFI (no internet)"
   fi
-  
+
 
 
   wifi=(
@@ -73,7 +76,7 @@ setscroll() {
 }
 
 case "$SENDER" in
-  "mouse.entered") setscroll on 
+  "mouse.entered") setscroll on
   ;;
   "mouse.exited") setscroll off
   ;;


### PR DESCRIPTION
Addresses macOS 26 WiFi SSID redaction by adding wifi-unredactor fallback when system_profiler returns <redacted>. Maintains backward compatibility and graceful degradation.